### PR TITLE
Tes 50 bugfix product card height

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7129,9 +7129,9 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -48,7 +48,7 @@ export const ProductCard: React.FC<ProductCardProps> = ({
             />
           </figcaption>
         </figure>
-        <p>{shortDescription}</p>
+        <p className="min-h-[72px]">{shortDescription}</p>
         <div className='flex items-center justify-between'>
           <p className='font-base font-bold text-grey-900'>
             {pricePerMonth}€/month


### PR DESCRIPTION
* there was a vulnerability in out package.json so I fixed that (run `npm audit fix`)
* Fixed the height of the product description, so in cases when it is shorter (two lines, instaed of 3), the rest of the card deosn't shift up. It's not the prettiest solution, but it solves the problem.

before fixing:
![image](https://github.com/user-attachments/assets/f172e867-0a02-4dbe-92a8-b109acae323e)


after fixing:
![image](https://github.com/user-attachments/assets/d09d2485-7293-4a85-ac89-81428de24264)
