### PR TITLE
#14 fix: headings order

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -39,8 +39,8 @@ export const ProductCard: React.FC<ProductCardProps> = ({
           </div>
           <figcaption className='flex flex-col gap-3'>
             <div className='flex flex-col gap-1'>
-              <h3 className='text-sm uppercase text-grey-800'>{brandName}</h3>
-              <h2 className='text-xl font-bold text-grey-900'>{modelName}</h2>
+              <h2 className='text-sm uppercase text-grey-800'>{brandName}</h2>
+              <h3 className='text-xl font-bold text-grey-900'>{modelName}</h3>
             </div>
             <ColorDots
               availableColors={availableColors}


### PR DESCRIPTION
There was a wrong order of headsings in the product card component, this could also lower the lighthouse scores. So I fixed that, now the h2 is rendred before the h3. As it should be