### PR TITLE
feat: disable ordering button when out of stock

### DIFF
--- a/src/__tests__/order/OrderErrorMessage.test.tsx
+++ b/src/__tests__/order/OrderErrorMessage.test.tsx
@@ -1,0 +1,16 @@
+import { OrderErrorMessage } from '@/components/forms/OrderErrorMessage';
+import { render, screen } from '@testing-library/react';
+
+describe('Order error message', () => {
+  it('Displays the correct text', () => {
+    render(<OrderErrorMessage />);
+    expect(
+      screen.getByText("Your order hasn't been placed")
+    ).toBeInTheDocument();
+  });
+
+  it('Displays the correct icon', () => {
+    render(<OrderErrorMessage />);
+    expect(screen.getByTestId('triangle-icon')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/order/OrderSuccessMessage.test.tsx
+++ b/src/__tests__/order/OrderSuccessMessage.test.tsx
@@ -1,0 +1,14 @@
+import { OrderSuccessMessage } from '@/components/forms/OrderSuccessMessage';
+import { render, screen } from '@testing-library/react';
+
+describe('Order success message', () => {
+  it('Displays the correct text', () => {
+    render(<OrderSuccessMessage />);
+    expect(screen.getByText("We've received your order")).toBeInTheDocument();
+  });
+
+  it('Displays the correct icon', () => {
+    render(<OrderSuccessMessage />);
+    expect(screen.getByTestId('check-icon')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/order/PlaceOrderModal.test.tsx
+++ b/src/__tests__/order/PlaceOrderModal.test.tsx
@@ -7,10 +7,32 @@ const mockProps = {
   setIsOpen: jest.fn(),
   brandName: 'Apple',
   modelName: 'iPhone 13',
-  selectedColor: { color: 'black', stockAmount: 10, image: '/black-iphone.jpg' },
+  selectedColor: {
+    color: 'black',
+    stockAmount: 10,
+    image: '/black-iphone.jpg',
+  },
+};
+
+const mockPropsOutOfStock = {
+  isOpen: true,
+  setIsOpen: jest.fn(),
+  brandName: 'Sony',
+  modelName: 'Xperia 10 V',
+  selectedColor: {
+    color: 'green',
+    stockAmount: 0,
+    image: '/green-sony_Xperia.png',
+  },
 };
 
 describe('PlaceOrderModal', () => {
+  it('is not opened because button is disabled when the stock amount is 0', () => {
+    render(<PlaceOrderModal {...mockPropsOutOfStock} />);
+    const orderNowBtn = screen.getByText('Order now');
+    expect(orderNowBtn).toBeDisabled();
+  });
+
   it('renders the header with the text "Finalise Your Order"', () => {
     render(<PlaceOrderModal {...mockProps} />);
 

--- a/src/components/forms/OrderErrorMessage.tsx
+++ b/src/components/forms/OrderErrorMessage.tsx
@@ -7,7 +7,7 @@ export const OrderErrorMessage = () => {
       style={{ borderLeftWidth: '6px' }}
     >
       <div className='text-error-medium flex items-center gap-2'>
-        <FaTriangleExclamation />
+        <FaTriangleExclamation data-testid='triangle-icon' />
         <p className='text-error-strong font-medium'>
           Your order hasn&apos;t been placed
         </p>

--- a/src/components/forms/OrderSuccessMessage.tsx
+++ b/src/components/forms/OrderSuccessMessage.tsx
@@ -7,7 +7,7 @@ export const OrderSuccessMessage = () => {
       style={{ borderLeftWidth: '6px' }}
     >
       <div className='flex items-center gap-2 text-success-medium'>
-        <FaCircleCheck />
+        <FaCircleCheck data-testid='check-icon' />
         <p className='font-medium text-success'>
           We&apos;ve received your order
         </p>

--- a/src/components/modals/PlaceOrderModal.tsx
+++ b/src/components/modals/PlaceOrderModal.tsx
@@ -32,7 +32,11 @@ export const PlaceOrderModal: React.FC<PlaceOrderModalProps> = ({
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
-        <Button icon={<FaArrowRight />} iconPosition='right'>
+        <Button
+          icon={<FaArrowRight />}
+          iconPosition='right'
+          disabled={selectedColor.stockAmount === 0}
+        >
           Order now
         </Button>
       </DialogTrigger>


### PR DESCRIPTION
Previously we missed disabling the 'Order now' button when the product is out of stock.
This is now implemented: when the stock amount is 0, the button is disabled.

![image](https://github.com/user-attachments/assets/05e2c803-0c04-4350-96c4-1e009ba5ae1f)

I also added a test case for that, and wrote tests for order success and order error messages.