### PR TITLE
refactor: product card width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7054,14 +7054,6 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "canvas": "^2.5.0"
-            },
-            "peerDependenciesMeta": {
-                "canvas": {
-                    "optional": true
-                }
             }
         },
         "node_modules/jest-environment-node": {
@@ -7669,7 +7661,7 @@
                 "node": ">=14"
             },
             "peerDependencies": {
-                "canvas": "^2.5.0"
+                "canvas": "null"
             },
             "peerDependenciesMeta": {
                 "canvas": {

--- a/src/__tests__/header/HeroSection.test.tsx
+++ b/src/__tests__/header/HeroSection.test.tsx
@@ -43,6 +43,6 @@ describe('BannerSection component', () => {
         });
 
         const titleElement = screen.getByRole('heading', { level: 1 });
-        expect(titleElement).toHaveClass(/lg:text-hero-title-lg/);
+        expect(titleElement).toHaveClass(/xl:text-hero-title-lg/);
     });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,7 +30,7 @@ export default function Home() {
         <>
             <Header />
             <BannerImage />
-            <main className='flex min-h-screen w-full flex-col items-center gap-y-10 p-main-content md:p-main-content-md xl:gap-y-12 xl:p-main-content-lg'>
+            <main className='m-auto flex min-h-screen w-full max-w-main-app flex-col items-center gap-y-10 p-main-content md:p-main-content-md xl:gap-y-12 xl:p-main-content-lg'>
                 <HeroSection
                     title='Mobile Phones & Accessories'
                     description='Discover the latest mobile phones and accessories to enhance your digital lifestyle. From sleek designs to powerful features, our selection offers something for everyone.'

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,8 +38,10 @@ export default function Home() {
                 <section className='w-full'>
                     <FilterAndSortProvider>
                         <FilterButtonsContainer />
-                        <div className='w-full md:grid md:grid-cols-1 xl:grid-cols-main-app'>
-                            <Filters />
+                        <div className='w-full gap-8 xl:grid xl:grid-cols-main-app'>
+                            <div className='hidden space-y-5 xl:block'>
+                                <Filters />
+                            </div>
                             <div className='xl:overflow-y-auto xl:p-1'>
                                 {/*To prevent the ProductGrid from being affected by the Filters components height changes */}
                                 <DynamicProductGrid />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,7 +30,7 @@ export default function Home() {
         <>
             <Header />
             <BannerImage />
-            <main className='flex min-h-screen w-full flex-col items-center gap-y-10 p-main-content md:p-main-content-md lg:gap-y-12 lg:p-main-content-lg'>
+            <main className='flex min-h-screen w-full flex-col items-center gap-y-10 p-main-content md:p-main-content-md xl:gap-y-12 xl:p-main-content-lg'>
                 <HeroSection
                     title='Mobile Phones & Accessories'
                     description='Discover the latest mobile phones and accessories to enhance your digital lifestyle. From sleek designs to powerful features, our selection offers something for everyone.'
@@ -38,9 +38,9 @@ export default function Home() {
                 <section className='w-full'>
                     <FilterAndSortProvider>
                         <FilterButtonsContainer />
-                        <div className='w-full md:grid md:grid-cols-1 lg:grid-cols-main-app'>
+                        <div className='w-full md:grid md:grid-cols-1 xl:grid-cols-main-app'>
                             <Filters />
-                            <div className='lg:overflow-y-auto lg:p-1'>
+                            <div className='xl:overflow-y-auto xl:p-1'>
                                 {/*To prevent the ProductGrid from being affected by the Filters components height changes */}
                                 <DynamicProductGrid />
                             </div>

--- a/src/components/filters/FilterButtonsContainer.tsx
+++ b/src/components/filters/FilterButtonsContainer.tsx
@@ -3,7 +3,7 @@ import { FilterModal } from '@/components/modals/FilterModal';
 
 export const FilterButtonsContainer: React.FC = () => {
     return (
-        <div className='mb-6 flex flex-wrap gap-4 lg:hidden'>
+        <div className='mb-6 flex flex-wrap gap-4 xl:hidden'>
             <FilterModal />
             <SortButton />
         </div>

--- a/src/components/filters/Filters.tsx
+++ b/src/components/filters/Filters.tsx
@@ -37,13 +37,13 @@ export const Filters = () => {
     ];
 
     return (
-        <div className='hidden space-y-5 xl:col-span-1 xl:block'>
+        <>
             <SortRadioGroup />
             <FilterCheckboxGroup
                 form={undefined}
                 filterSections={filterSections}
                 onImmediateChange={handleImmediateChange}
             />
-        </div>
+        </>
     );
 };

--- a/src/components/filters/Filters.tsx
+++ b/src/components/filters/Filters.tsx
@@ -37,7 +37,7 @@ export const Filters = () => {
     ];
 
     return (
-        <div className='hidden space-y-5 lg:col-span-1 lg:block'>
+        <div className='hidden space-y-5 xl:col-span-1 xl:block'>
             <SortRadioGroup />
             <FilterCheckboxGroup
                 form={undefined}

--- a/src/components/filters/SortMenuSheet.tsx
+++ b/src/components/filters/SortMenuSheet.tsx
@@ -69,7 +69,7 @@ export const SortMenuSheet: React.FC = () => {
                         </Button>
                     </div>
                     <SheetClose asChild>
-                        <Button variant='action' role='button' size='sm'>
+                        <Button variant='action' role='button' size='xs'>
                             Done
                         </Button>
                     </SheetClose>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -5,7 +5,7 @@ import logo from 'public/logo.svg';
 export const Header = () => {
     return (
         <header className='sticky top-0 z-10'>
-            <nav className='mx-auto flex bg-white p-4 lg:ps-16'>
+            <nav className='mx-auto flex bg-white p-4 xl:ps-16'>
                 <Link href='/'>
                     <Image src={logo} alt='Company logo' priority />
                 </Link>

--- a/src/components/header/HeroSection.tsx
+++ b/src/components/header/HeroSection.tsx
@@ -6,10 +6,10 @@ export const HeroSection: React.FC<HeroSectionProps> = ({
 }) => {
     return (
         <section className='flex w-full flex-col gap-y-5'>
-            <h1 className='text-hero-title font-bold md:text-hero-title-md lg:text-hero-title-lg'>
+            <h1 className='text-hero-title font-bold md:text-hero-title-md xl:text-hero-title-lg'>
                 {title}
             </h1>
-            <p className='text-base lg:text-2xl'>{description}</p>
+            <p className='text-base xl:text-2xl'>{description}</p>
         </section>
     );
 };

--- a/src/components/modals/PlaceOrderModal.tsx
+++ b/src/components/modals/PlaceOrderModal.tsx
@@ -42,7 +42,7 @@ export const PlaceOrderModal: React.FC<PlaceOrderModalProps> = ({
                     Order now
                 </Button>
             </DialogTrigger>
-            <DialogContent className='size-full max-w-full rounded-none sm:rounded-none md:flex md:max-h-dialog-content md:max-w-dialog-content md:gap-0 md:rounded-md md:border-0 md:p-0'>
+            <DialogContent className='size-full max-w-full rounded-none xs:rounded-none md:flex md:max-h-dialog-content md:max-w-dialog-content md:gap-0 md:rounded-md md:border-0 md:p-0'>
                 <div className='relative hidden md:block md:w-image-container'>
                     <Image
                         src='/form-decoration.png'

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -49,7 +49,7 @@ export const ProductCard: React.FC<ProductCardProps> = ({
                             <h2 className='text-sm uppercase text-grey-800'>
                                 {brand}
                             </h2>
-                            <h3 className='text-xl font-bold text-grey-900'>
+                            <h3 className='text-balance text-xl font-bold text-grey-900'>
                                 {name}
                             </h3>
                         </div>

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -23,7 +23,7 @@ export const ProductCard: React.FC<ProductCardProps> = ({
     return (
         <div
             data-testid={`product-card-${id}`}
-            className='aspect-card w-card-width rounded-lg bg-grey-100 outline outline-1 outline-grey-200'
+            className='rounded-lg bg-grey-100 outline outline-1 outline-grey-200 sm:w-full'
         >
             <div className='flex flex-col gap-4 p-6'>
                 <figure className='grid h-card-img-height grid-cols-2 items-center justify-center'>

--- a/src/components/product/ProductGrid.tsx
+++ b/src/components/product/ProductGrid.tsx
@@ -30,7 +30,7 @@ export const ProductGrid: React.FC = () => {
     return (
         <div
             data-testid='product-grid'
-            className='flex flex-wrap justify-center gap-4 md:justify-start'
+            className='xxl:grid-cols-4 grid grid-cols-1 justify-center gap-6 sm:grid-cols-2 md:justify-start lg:grid-cols-3'
         >
             {error && <Error>{error}</Error>}
             {products.map((product: ProductCardProps) => (

--- a/src/components/product/ProductGrid.tsx
+++ b/src/components/product/ProductGrid.tsx
@@ -30,7 +30,7 @@ export const ProductGrid: React.FC = () => {
     return (
         <div
             data-testid='product-grid'
-            className='grid grid-cols-1 justify-center gap-6 sm:grid-cols-2 md:justify-start lg:grid-cols-3 xxl:grid-cols-4'
+            className='grid grid-cols-card-grid justify-center gap-6'
         >
             {error && <Error>{error}</Error>}
             {products.map((product: ProductCardProps) => (

--- a/src/components/product/ProductGrid.tsx
+++ b/src/components/product/ProductGrid.tsx
@@ -30,7 +30,7 @@ export const ProductGrid: React.FC = () => {
     return (
         <div
             data-testid='product-grid'
-            className='xxl:grid-cols-4 grid grid-cols-1 justify-center gap-6 sm:grid-cols-2 md:justify-start lg:grid-cols-3'
+            className='grid grid-cols-1 justify-center gap-6 sm:grid-cols-2 md:justify-start lg:grid-cols-3 xxl:grid-cols-4'
         >
             {error && <Error>{error}</Error>}
             {products.map((product: ProductCardProps) => (

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -19,7 +19,7 @@ const buttonVariants = cva(
                     'bg-primary-dark text-white hover:bg-primary focus-visible:ring-primary-light focus-visible:ring-offset-2 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-800/80',
                 ghost: 'hover:text-slate-900 dark:hover:bg-slate-800 dark:hover:text-slate-50',
                 link: 'text-slate-900 underline-offset-4 hover:underline dark:text-slate-50',
-                filter: 'w-full min-w-fit flex-1 border border-primary-light px-5 text-primary-light hover:border-primary-dark hover:bg-primary-active hover:text-primary-dark active:border-primary-dark active:bg-primary-active active:text-primary-dark sm:w-auto md:max-w-fit',
+                filter: 'w-full min-w-fit flex-1 border border-primary-light px-5 text-primary-light hover:border-primary-dark hover:bg-primary-active hover:text-primary-dark active:border-primary-dark active:bg-primary-active active:text-primary-dark xs:w-auto md:max-w-fit',
                 close: 'border border-primary-dark text-primary-dark hover:bg-primary-active',
                 results: 'bg-primary-dark text-white hover:bg-primary',
                 done: 'absolute right-3 top-2.5 text-white underline-offset-4 opacity-70 transition-opacity hover:opacity-100 focus:outline-none disabled:pointer-events-none data-[state=open]:bg-slate-100 dark:data-[state=open]:bg-slate-800',
@@ -27,7 +27,7 @@ const buttonVariants = cva(
             },
             size: {
                 default: 'h-10 px-6 py-4',
-                sm: 'h-9 rounded-md px-3',
+                xs: 'h-9 rounded-md px-3',
                 lg: 'h-11 rounded-md px-8',
                 icon: 'size-10',
                 picker: 'h-7',

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
         <DialogPrimitive.Content
             ref={ref}
             className={cn(
-                'fixed left-[50%] top-[50%] z-50 grid w-full max-w-xl translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden border border-slate-200 bg-white p-4 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] dark:border-slate-800 dark:bg-slate-950 sm:rounded-lg',
+                'fixed left-[50%] top-[50%] z-50 grid w-full max-w-xl translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden border border-slate-200 bg-white p-4 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] dark:border-slate-800 dark:bg-slate-950 xs:rounded-lg',
                 className
             )}
             {...props}
@@ -59,7 +59,7 @@ const DialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
     <div
         className={cn(
-            'flex flex-col space-y-1.5 text-center sm:text-left',
+            'flex flex-col space-y-1.5 text-center xs:text-left',
             className
         )}
         {...props}
@@ -73,7 +73,7 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
     <div
         className={cn(
-            'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+            'flex flex-col-reverse xs:flex-row xs:justify-end xs:space-x-2',
             className
         )}
         {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -71,7 +71,7 @@ const SheetHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
     <div
         className={cn(
-            'flex flex-col space-y-2 text-center sm:text-left',
+            'flex flex-col space-y-2 text-center xs:text-left',
             className
         )}
         {...props}

--- a/src/lib/services/apiClient.ts
+++ b/src/lib/services/apiClient.ts
@@ -1,7 +1,7 @@
 import axios, { CanceledError } from 'axios';
 
 export default axios.create({
-    baseURL: 'https://henrika.eu-central-1.elasticbeanstalk.com/api/',
+    baseURL: 'http://henrika.eu-central-1.elasticbeanstalk.com/api/',
 });
 
 export { CanceledError };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -83,6 +83,7 @@ const config = {
                 'form-container': 'calc(100%-image-container)',
             },
             maxWidth: {
+                'main-app': '1800px',
                 'dialog-content': '888px',
                 'btn-order': '156px',
             },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -100,7 +100,8 @@ const config = {
                 'dialog-content': '640px',
             },
             gridTemplateColumns: {
-                'main-app': '1fr 4fr',
+                'card-grid': 'repeat(auto-fit, minmax(300px, 1fr))',
+                'main-app': 'max-content auto',
             },
             borderWidth: {
                 DEFAULT: '1px',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,9 +13,12 @@ const config = {
     prefix: '',
     theme: {
         screens: {
-            sm: '375px',
+            xs: '375px',
+            sm: '576px',
             md: '768px',
-            lg: '1440px',
+            lg: '876px',
+            xl: '1440px',
+            xxl: '1920px',
         },
         container: {
             center: true,
@@ -74,12 +77,8 @@ const config = {
                 'sheet-gradient':
                     'linear-gradient(180deg, #7A7A7A 0%, #4A4A4A 100%)',
             },
-            aspectRatio: {
-                card: '318 / 336',
-            },
             width: {
                 'image-container': '300px',
-                'card-width': '318px',
                 'card-img-width': '100px',
                 'form-container': 'calc(100%-image-container)',
             },


### PR DESCRIPTION
From a set width with set aspect ratio, the product card was refactored to be full width.
`ProductGrid` was refactored to use grid instead of flex - this change needed extra braekpoints
now, on xsmall and small devices there is 1 column of product cards, on medium there are 2 columns, on large there are 3 and so on. Breakpoints fall somewhere between our previous ones and standard Bootstrap breakpoints.

changing breakpoints (naming: required changes elsewhere in the code, to keep the previous sizes and the new breakpoint values/names.
OLD:
```js
screens: {
            sm: '375px',
            md: '768px',
            lg: '1440px',
        },
```
NEW:
```js
screens: {
            xs: '375px',
            sm: '576px',
            md: '768px',
            lg: '876px',
            xl: '1440px',
            xxl: '1920px',
        },
```

xs: 375px
![image](https://github.com/user-attachments/assets/9e157a82-5e38-4138-b881-d4bbbaa5e342)

ipadmini 768px
![image](https://github.com/user-attachments/assets/e5822d61-db50-42e6-9b47-b288895fad78)

ipadpro
![image](https://github.com/user-attachments/assets/c4cad9e3-c1ab-4cce-96d3-321e07d4a99f)
![image](https://github.com/user-attachments/assets/0b72eb83-4548-4a0e-8aaa-8ff9d8115715)

desktop:
![image](https://github.com/user-attachments/assets/51de3383-85c0-44eb-b282-603221d7025f)

very big desktop 2560x1440 (27" screens)
![image](https://github.com/user-attachments/assets/68f48c4a-b92b-4d26-bd06-c5b5fbac6a07)

the last view may need adjustments, but since we want to add max-width to the main container it may be fine. Therefore I'm leaving it as it is for now.