### PR TITLE
Reactor/improvement UX: loading skeletons instead of loader

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,11 +18,11 @@ const DynamicProductGrid = dynamic(
     () =>
         import('@/components/product/ProductGrid').then(
             (mod) => mod.ProductGrid
-        ),
-    {
-        loading: () => <Loader />,
-        ssr: false,
-    }
+        )
+    // {
+    //     loading: () => <Loader />,
+    //     ssr: false,
+    // }
 );
 
 export default function Home() {

--- a/src/components/product/ProductCardSkeleton.tsx
+++ b/src/components/product/ProductCardSkeleton.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export const ProductCardSkeleton = () => {
+    return (
+        <div className='flex flex-col gap-4 rounded-lg p-6 outline outline-1 outline-grey-100 sm:w-full'>
+            <Skeleton className='h-card-img-height' />
+            <div className='flex min-h-card-description flex-col gap-3'>
+                <Skeleton className='h-4' />
+                <Skeleton className='h-4' />
+                <Skeleton className='h-4 w-40' />
+            </div>
+            <Skeleton className='ms-auto h-10 w-44 rounded-full' />
+        </div>
+    );
+};

--- a/src/components/product/ProductGrid.tsx
+++ b/src/components/product/ProductGrid.tsx
@@ -4,12 +4,14 @@ import React, { useEffect, useState } from 'react';
 import { CanceledError } from '@/lib/services/apiClient';
 import { Error } from '@/components/apiResponseState/Error';
 import { ProductCard } from '@/components/product/ProductCard';
+import { ProductCardSkeleton } from '@/components/product/ProductCardSkeleton';
 import productService from '@/lib/services/productService';
 
 export const ProductGrid: React.FC = () => {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
     const [products, setProducts] = useState<ProductData[]>([]);
+    const skeletons = [1, 2, 3, 4, 5, 6];
 
     useEffect(() => {
         const { request, cancel } = productService.getObject<APIProductData>();
@@ -33,6 +35,10 @@ export const ProductGrid: React.FC = () => {
             className='grid grid-cols-1 justify-center gap-6 sm:grid-cols-2 md:justify-start lg:grid-cols-3 xxl:grid-cols-4'
         >
             {error && <Error>{error}</Error>}
+            {loading &&
+                skeletons.map((skeleton) => (
+                    <ProductCardSkeleton key={skeleton} />
+                ))}
             {products.map((product: ProductCardProps) => (
                 <ProductCard key={product.id} {...product} />
             ))}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,18 @@
+import { cn } from '@/lib/utils';
+
+function Skeleton({
+    className,
+    ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+    return (
+        <div
+            className={cn(
+                'animate-pulse rounded-md bg-primary-light/15 dark:bg-slate-800',
+                className
+            )}
+            {...props}
+        />
+    );
+}
+
+export { Skeleton };


### PR DESCRIPTION
I merged here the branch that changes card dimensions, because it was needed to make the skeletons the same size as the card.

- installed Skeleton from shadcn
- created a ProductCardSkeleton
- substituted the Loader for the ProductCardSkeleton

I decided to leave the loader in the code for now as we may need it later.